### PR TITLE
Fix missing parameter rename

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -493,7 +493,7 @@ if __name__ == "__main__":
         else:
             for ch_id in [x["id"] for x in ch_list]:
                 ch_hist = channel_history(ch_id, oldest=a.fr, latest=a.to)
-                save_channel(ch_hist, ch_id, ch_list, users)
+                save_channel(ch_hist, ch_id, ch_list, user_list)
     # elif, since we want to avoid asking for channel_history twice
     elif a.r:
         for ch_id in [x["id"] for x in channel_list()]:


### PR DESCRIPTION
In 27d1053a27e2640de13071ec8f4badf8a8f9823e the signature of
save_channel() was updated and the users variable was removed from the
main function but one save_channel() call was still using it.

Fix that by calling save_channel() with user_list in the missing
instance.

Fixes #10 