### PR TITLE
Fix `OSError` on invalid filename

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -7,6 +7,7 @@ from timeit import default_timer
 from datetime import datetime
 import argparse
 from dotenv import load_dotenv
+from pathvalidate import sanitize_filename
 from time import sleep
 
 # when rate-limited, add this to the wait time
@@ -402,6 +403,7 @@ def save_files(out_dir):
     start = default_timer()
     for file_info in get_file_list():
         url = file_info["url_private"]
+        file_info["name"] = sanitize_filename(file_info["name"])
         destination_filename = "{id}-{name}".format(**file_info)
         files_dir = os.path.join(out_dir, "files")
         os.makedirs(files_dir, exist_ok=True)
@@ -465,7 +467,7 @@ if __name__ == "__main__":
     if a.o is None and a.files:
         print("If you specify --files you also need to specify an output directory with -o")
         sys.exit(1)
-        
+
     if a.o is not None:
         out_dir_parent = os.path.abspath(
             os.path.expanduser(os.path.expandvars(a.o))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask~=1.1.2
 requests~=2.24.0
 python-dotenv~=0.15.0
+pathvalidate~=2.5.2


### PR DESCRIPTION
This happens if the filename of a downloaded file contains invalid characters for the current OS, e.g. a filename containing `?` or `/` on Windows.

Also added `pathvalidate` as a requirement (https://pypi.org/project/pathvalidate/).