### PR TITLE
Update readme to reflect current Slack app creation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A similar service is provided by Slack for workspace admins at [https://my.slack
 There are two ways to use `slack-exporter` (detailed below). Both require a Slack API token to be able to communicate with your workspace.
 
 1. Visit [https://api.slack.com/apps/](https://api.slack.com/apps/) and sign in to your workspace.
-2. Click `Create New App`, enter a name (e.g., `Slack Exporter`), and select your workspace.
-3. In prior versions of the Slack API, OAuth permissions had to be specified manually. Now, when prompted for an App Manifest, just paste in the contents of the `slack.yaml` file in the root of this repo.
+2. Click `Create New App`. If prompted to select "how you’d like to configure your app’s scopes", choose the "app manifest option" (you will otherwise be prompted to enter an app name and may need to go through more steps to set up permissions instead of the short way in step 3), then select your workspace.
+3. You should then be prompted for an App Manifest; paste the contents of the `slack.yaml` file (in the root of this repo) into the YAML box.
 4. Select `Install to Workspace` at the top of that page (or `Reinstall to Workspace` if you have done this previously) and accept at the prompt.
-5. Copy the `OAuth Access Token` (which will generally start with `xoxp` for user-level permissions)
+5. Copy the `OAuth Access Token` (which will generally start with `xoxp` for user-level permissions and may be located in a section like "OAuth & Permissions" in the sidebar).
 
 ## Usage
 
@@ -32,7 +32,8 @@ There are two ways to use `slack-exporter` (detailed below). Both require a Slac
     export SLACK_USER_TOKEN=xoxp-xxxxxxxxxxxxx...
     ```
 
-2. Run `python exporter.py --help` to view the available export options.
+2. If you cloned this repository, make sure that dependencies are installed by running `pip install -r requirements.txt` in the directory.
+3. Run `python exporter.py --help` to view the available export options. You can test that access is working by listing the available conversations: `python exporter.py --lc`.
 
 ### As a Slack bot
 


### PR DESCRIPTION
Slack showed a slightly different order of dialog boxes during the Create New App workflow, so I have added details for that, along with a tip on the Python installation required before running the CLI command.
Thank you!